### PR TITLE
New Feature: Delete Replies Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
+# de-x-replies.py
+
+**de-x-replies.py** is a Python script designed to delete all of your replies on Twitter without requiring access to the official Twitter API. The script leverages session headers from an authenticated Twitter session to delete only the replies from your tweet history, leaving your original tweets untouched.
+
+## Features
+
+- **Delete Replies Only**: This script identifies and deletes only replies, based on the `in_reply_to_status_id_str` field in Twitter's tweet data.
+- **No Twitter API Required**: The script works by using session request headers, so no need for API keys or tokens.
+- **Simple and Automated**: Provide the script with a JSON file of your tweet data and a file with request headers, and it will handle the rest.
+
+## How It Works
+
+1. **Input Files**:
+   - **Tweet Data (JSON)**: A file that contains your tweet history, typically exported from Twitter or captured via a web session.
+   - **Request Headers**: A file containing the session headers captured from your authenticated Twitter session (this can be done via browser developer tools).
+
+2. **Deletion Process**:
+   - The script scans the tweet data for replies (identified by the `in_reply_to_status_id_str` field being non-null).
+   - For each reply found, the script sends a delete request to Twitter's GraphQL API.
+
+## Usage
+
+### Prerequisites
+
+- **Python 3.x** installed on your system.
+- **requests** library installed. You can install it using `pip`:
+  ```bash
+  pip install requests
+
+
 # de-x.py
 
 **This script can be used to delete the whole history of your tweets, retweets and replies.**

--- a/de-x-replies.py
+++ b/de-x-replies.py
@@ -1,0 +1,81 @@
+##
+# de-x-replies.py -- delete all your replies w/o API access
+# Copyright 2023 Thorsten Schroeder
+#
+# Published under 2-Clause BSD License (https://opensource.org/license/bsd-2-clause/)
+#
+# Please see README.md for more information
+##
+
+import sys
+import json
+import requests
+
+def get_reply_ids(json_data):
+
+    result = []
+    data = json.loads(json_data)
+
+    for d in data:
+        # Check if the tweet is a reply (in_reply_to_status_id_str is not null)
+        if d['tweet'].get('in_reply_to_status_id_str') is not None:
+            result.append(d['tweet']['id_str'])
+
+    return result
+
+def parse_req_headers(request_file):
+
+    sess = {}
+
+    with open(request_file) as f:
+        line = f.readline()
+        while line:
+            try:
+                k, v = line.split(':', 1)
+                val = v.lstrip().rstrip()
+                sess[k] = val
+            except:
+                # ignore empty lines
+                pass
+
+            line = f.readline()
+
+    return sess
+
+def main(ac, av):
+
+    if(ac != 3):
+        print(f"[!] usage: {av[0]} <jsonfile> <req-headers>")
+        return
+
+    f = open(av[1], encoding='UTF-8')
+    raw = f.read()
+    f.close()
+
+    # skip data until first '['
+    i = raw.find('[')
+    reply_ids = get_reply_ids(raw[i:])
+
+    session = parse_req_headers(av[2])
+
+    for i in reply_ids:
+        delete_tweet(session, i)
+        # maybe add some random sleep here to prevent future rate-limiting
+
+def delete_tweet(session, tweet_id):
+
+    print(f"[*] delete tweet-id {tweet_id}")
+    delete_url = "https://twitter.com/i/api/graphql/VaenaVgh5q5ih7kvyVjgtg/DeleteTweet"
+    data = {"variables":{"tweet_id":tweet_id,"dark_request":False},"queryId":"VaenaVgh5q5ih7kvyVjgtg"}
+
+    # set or re-set correct content-type header
+    session["content-type"] = 'application/json'
+    r = requests.post(delete_url, data=json.dumps(data), headers=session)
+    print(r.status_code, r.reason)
+    print(r.text[:500] + '...')
+
+    return
+
+if __name__ == '__main__':
+
+    main(len(sys.argv), sys.argv)


### PR DESCRIPTION
### Feature: Delete Replies Only

This pull request introduces a new feature that allows users to delete only their Twitter replies, without affecting their regular tweets. The feature works by checking if a tweet is a reply (`in_reply_to_status_id_str` is not null) and deleting it if it qualifies.

#### Changes:
- Updated `get_tweet_ids` function to filter for replies only.
- Kept the tweet deletion process the same, leveraging the existing structure.
- Added documentation and comments in the script to reflect the new functionality.

I believe this feature will be useful for users who want to delete their replies without impacting their original tweets.

